### PR TITLE
Print IPV4 address and correct port for starting server

### DIFF
--- a/lib/FetchIPV4.js
+++ b/lib/FetchIPV4.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var os = require('os');
+var ifaces = os.networkInterfaces();
+
+// print out ipv4 address (for output in console)
+// https://stackoverflow.com/questions/3653065/get-local-ip-address-in-node-js
+function main() {
+  let res = "";
+  Object.keys(ifaces).forEach(function (ifname) {
+    var alias = 0;
+
+    ifaces[ifname].forEach(function (iface) {
+      if ('IPv4' !== iface.family || iface.internal !== false) {
+        // skip over internal (i.e. 127.0.0.1) and non-ipv4 addresses
+        return;
+      }
+
+      if (alias >= 1) {
+        // this single interface has multiple ipv4 addresses
+        // console.log(ifname + ':' + alias, iface.address);
+        res = iface.address;
+      } else {
+        // this interface has only one ipv4 adress
+        // console.log(ifname, iface.address);
+        res = iface.address;
+      }
+      ++alias;
+    });
+  });
+  return res;
+}
+
+module.exports = main;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,8 +1,15 @@
 const {
   app
 } = require("../routes");
+const GetIPV4 = require('./FetchIPV4');
+
+// config
+const IPV4 = GetIPV4();
+const IP = (IPV4 == "") ? "localhost" : IPV4;
 const PORT = 3000; // process.env.PORT || 3000;
 
 app.listen(PORT, () => {
-  console.log(`listening on port 3000! http://localhost:3000/`);
+  console.log('App started and listening!');
+  console.log(`Local URL  : http://localhost:${PORT}/`);
+  console.log(`Network URL: http://${IP}:${PORT}/`);
 });


### PR DESCRIPTION
This is mainly a debugging/convenience feature; It doesn't close anything.

Not much but reads in the IPV4 address if there is one and outputs the correct port instead of always "localhost:3000".

Edit: I should add I'm using another device on the same network for debugging.