### PR TITLE
Fix typo & anchor elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://tamudatathon.com/">
+  <a href="https://tamudatathon.com/" target="_blank">
     <img src="/static/img/logos/main.png" width="80" />
   </a>
 </p>
@@ -10,10 +10,12 @@
 </h1>
 
 <p align="center">
-    Website deployment for TAMUdatathon
-    [[QA Website]](https://gigabowser.now.sh) [[Production Website]](https://tamudatathon.com)
+    Website deployment for TAMUDatathon
+    <br />
+    <a href="https://gigabowser.now.sh" target="_blank">QA Website</a>
+    |
+    <a href="https://tamudatathon.com" target="_blank">Production Website</a>
 </p>
-
 
 ## :wrench: Installation
 ```


### PR DESCRIPTION
- Markdown syntax was off, mixed with HTML syntax
- open all links in new tab